### PR TITLE
enable std on rustls-webpki

### DIFF
--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1"
 quinn = { version = "0.11", default-features = false, features = [
     "futures-io",
 ] }
+rustls-webpki = { version = "0.102", features = ["std"] }
 tokio-util = { version = "0.7.9" }
 futures = { version = "0.3.28" }
 tokio = { version = "1", features = ["io-util"], default-features = false }


### PR DESCRIPTION
The `rustls-platform-verifier` deliberately disables some default flags which messes up dependency settings on linux builds. Will file a bug with upstream.

This is a workaround to fix the issue.