### PR TITLE
cargo: follow-up on rustls/rustls-platform-verifier#164

### DIFF
--- a/h3-quinn/Cargo.toml
+++ b/h3-quinn/Cargo.toml
@@ -18,7 +18,6 @@ bytes = "1"
 quinn = { version = "0.11", default-features = false, features = [
     "futures-io",
 ] }
-rustls-webpki = { version = "0.102", features = ["std"] }
 tokio-util = { version = "0.7.9" }
 futures = { version = "0.3.28" }
 tokio = { version = "1", features = ["io-util"], default-features = false }

--- a/h3-quinn/src/lib.rs
+++ b/h3-quinn/src/lib.rs
@@ -499,13 +499,8 @@ impl quic::RecvStream for RecvStream {
 
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     fn recv_id(&self) -> StreamId {
-        self.stream
-            .as_ref()
-            .unwrap()
-            .id()
-            .0
-            .try_into()
-            .expect("invalid stream id")
+        let id_repr: u64 = self.stream.as_ref().unwrap().id().into();
+        id_repr.try_into().expect("invalid stream id")
     }
 }
 
@@ -646,13 +641,8 @@ where
 
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]
     fn send_id(&self) -> StreamId {
-        self.stream
-            .as_ref()
-            .unwrap()
-            .id()
-            .0
-            .try_into()
-            .expect("invalid stream id")
+        let id_repr: u64 = self.stream.as_ref().unwrap().id().into();
+        id_repr.try_into().expect("invalid stream id")
     }
 }
 


### PR DESCRIPTION
The problem was fixed upstream. Unfortunately, the dep-upgrade causes API-breaking changes in h3.